### PR TITLE
Better get_n_closest function that tries to match other_tags

### DIFF
--- a/services/mongodb.py
+++ b/services/mongodb.py
@@ -48,6 +48,7 @@ db = client.kagame
 catalogue = db.catalogue
 users = db.users
 wardrobe = db.wardrobe
+tag_embeddings = db.tag_embeddings
 metadata_collection = db.metadata
 
 CATALOGUE_COLLECTION_NAME = "catalogue"

--- a/services/openai.py
+++ b/services/openai.py
@@ -1,6 +1,7 @@
+from typing import List, Optional, Literal
 from openai import OpenAI
 from secretstuff.secret import OPENAI_API_KEY, OPENAI_ORG_ID, OPENAI_PROJ_ID
-from services.mongodb import catalogue
+from services.mongodb import catalogue, tag_embeddings
 from services.metadata import get_catalogue_metadata
 from pydantic import BaseModel
 import random
@@ -12,117 +13,118 @@ category_labels = ["Tops", "Bottoms", "Dresses", "Shoes", "Jackets", "Accessorie
 # Fixed formats which GPT4 will force to return
 
 create_outfit_tool = {
-      "type": "function",
-      "function": {
+    "type": "function",
+    "function": {
         "name": "create_outfit",
         "description": "Assembles an outfit consisting of top, bottom, and shoes with specified attributes.",
         "parameters": {
-          "type": "object",
-          "required": [
-            "top",
-            "shoes",
-            "bottom"
-          ],
-          "properties": {
-            "top": {
-              "type": "object",
-              "required": [
-                "color",
-                "material",
-                "other_tags",
-                "clothing_type"
-              ],
-              "properties": {
-                "color": {
-                  "type": "string",
-                  "description": "Color of the top garment"
+            "type": "object",
+            "required": [
+                "top",
+                "shoes",
+                "bottom"
+            ],
+            "properties": {
+                "top": {
+                    "type": "object",
+                    "required": [
+                        "color",
+                        "material",
+                        "other_tags",
+                        "clothing_type"
+                    ],
+                    "properties": {
+                        "color": {
+                            "type": "string",
+                            "description": "Color of the top garment"
+                        },
+                        "material": {
+                            "type": "string",
+                            "description": "Material from which the top is made"
+                        },
+                        "other_tags": {
+                            "type": "array",
+                            "description": "List of tags describing the style of the top",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "clothing_type": {
+                            "type": "string",
+                            "description": "Type of clothing for the top"
+                        }
+                    },
+                    "additionalProperties": False
                 },
-                "material": {
-                  "type": "string",
-                  "description": "Material from which the top is made"
+                "shoes": {
+                    "type": "object",
+                    "required": [
+                        "color",
+                        "material",
+                        "other_tags",
+                        "clothing_type"
+                    ],
+                    "properties": {
+                        "color": {
+                            "type": "string",
+                            "description": "Color of the shoes"
+                        },
+                        "material": {
+                            "type": "string",
+                            "description": "Material from which the shoes are made"
+                        },
+                        "other_tags": {
+                            "type": "array",
+                            "description": "List of tags describing the style of the shoes",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "clothing_type": {
+                            "type": "string",
+                            "description": "Type of shoes"
+                        }
+                    },
+                    "additionalProperties": False
                 },
-                "other_tags": {
-                  "type": "array",
-                  "description": "List of tags describing the style of the top",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "clothing_type": {
-                  "type": "string",
-                  "description": "Type of clothing for the top"
+                "bottom": {
+                    "type": "object",
+                    "required": [
+                        "color",
+                        "material",
+                        "other_tags",
+                        "clothing_type"
+                    ],
+                    "properties": {
+                        "color": {
+                            "type": "string",
+                            "description": "Color of the bottom garment"
+                        },
+                        "material": {
+                            "type": "string",
+                            "description": "Material from which the bottom is made"
+                        },
+                        "other_tags": {
+                            "type": "array",
+                            "description": "List of tags describing the style of the bottom",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "clothing_type": {
+                            "type": "string",
+                            "description": "Type of clothing for the bottom"
+                        }
+                    },
+                    "additionalProperties": False
                 }
-              },
-              "additionalProperties": False
             },
-            "shoes": {
-              "type": "object",
-              "required": [
-                "color",
-                "material",
-                "other_tags",
-                "clothing_type"
-              ],
-              "properties": {
-                "color": {
-                  "type": "string",
-                  "description": "Color of the shoes"
-                },
-                "material": {
-                  "type": "string",
-                  "description": "Material from which the shoes are made"
-                },
-                "other_tags": {
-                  "type": "array",
-                  "description": "List of tags describing the style of the shoes",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "clothing_type": {
-                  "type": "string",
-                  "description": "Type of shoes"
-                }
-              },
-              "additionalProperties": False
-            },
-            "bottom": {
-              "type": "object",
-              "required": [
-                "color",
-                "material",
-                "other_tags",
-                "clothing_type"
-              ],
-              "properties": {
-                "color": {
-                  "type": "string",
-                  "description": "Color of the bottom garment"
-                },
-                "material": {
-                  "type": "string",
-                  "description": "Material from which the bottom is made"
-                },
-                "other_tags": {
-                  "type": "array",
-                  "description": "List of tags describing the style of the bottom",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "clothing_type": {
-                  "type": "string",
-                  "description": "Type of clothing for the bottom"
-                }
-              },
-              "additionalProperties": False
-            }
-          },
-          "additionalProperties": False
+            "additionalProperties": False
         },
         "strict": True
-      }
     }
+}
+
 
 class ClothingTag(BaseModel):  # For catalogue
     clothing_type: str
@@ -130,8 +132,10 @@ class ClothingTag(BaseModel):  # For catalogue
     material: str
     other_tags: list[str]
 
-#store the recommendations given to the user, to allow for feedback to be given - then store the feedback to make next recommendations better
-#I have no idea how to store this for each user and how to load in when logging in
+# store the recommendations given to the user, to allow for feedback to be given - then store the feedback to make next recommendations better
+# I have no idea how to store this for each user and how to load in when logging in
+
+
 class UserPersona(BaseModel):
     age: int
     gender: str
@@ -139,12 +143,13 @@ class UserPersona(BaseModel):
     skin_tone: str
     style: list[str]
 
-    #recommendations: {'item':ClothingTag, recommended: [{'top':clothingTag, 'bottom':clothingTag, 'shoes':clothingTag}]}
+    # recommendations: {'item':ClothingTag, recommended: [{'top':clothingTag, 'bottom':clothingTag, 'shoes':clothingTag}]}
     recommendations: dict[str, list[dict[str, ClothingTag]] | ClothingTag]
 
-    #preferences: {'tops': ["casual tee shirts","textual graphics tee shirts"],'bottoms': ["jeans","trousers"],'shoes': ["sneakers","boots"]}}
-    #idea is to populate this when the user gives fedback on the recommendations, keep maybe 3 preferences for each category -> to be updated with each feedback
+    # preferences: {'tops': ["casual tee shirts","textual graphics tee shirts"],'bottoms': ["jeans","trousers"],'shoes': ["sneakers","boots"]}}
+    # idea is to populate this when the user gives fedback on the recommendations, keep maybe 3 preferences for each category -> to be updated with each feedback
     preferences: dict[str, list[str]]
+
 
 class ClothingTagEmbed(BaseModel):  # For catalogue
     clothing_type_embed: list[float]
@@ -226,7 +231,7 @@ def str_to_clothing_tag(search: str) -> ClothingTag:
                 ]
             },
             {
-                "role": "user", 
+                "role": "user",
                 "content": [
                     {
                         "type": "text",
@@ -240,15 +245,17 @@ def str_to_clothing_tag(search: str) -> ClothingTag:
     # TODO(maybe): Convert it to lowercase by code, in case chatgpt ignores the prompt and puts uppercase chars.
     return ClothingTag(**json.loads(output.choices[0].message.content))
 
-#TODO: safety to not prompt inject the additional prompt
-def generate_outfit_recommendations(item: ClothingTag, additional_prompt: str,user) -> ClothingTag:
+# TODO: safety to not prompt inject the additional prompt
+
+
+def generate_outfit_recommendations(item: ClothingTag, additional_prompt: str, user) -> ClothingTag:
     age = user.age
     gender = user.gender
     skin_tone = user.skin_tone
     style = user.style
     preferences = user.preferences
 
-    #making a nice sentence about user preferences to inclcude in prompt
+    # making a nice sentence about user preferences to inclcude in prompt
     parts = []
     if preferences == {}:
         user_preferences = ""
@@ -261,7 +268,7 @@ def generate_outfit_recommendations(item: ClothingTag, additional_prompt: str,us
             parts.append(f"{', '.join(preferences['shoes'])}")
         user_preferences = f"The user prefers wearing: {', '.join(parts)}."
 
-    #if there is no additional prompt, we don't want to include it in the prompt
+    # if there is no additional prompt, we don't want to include it in the prompt
     if not additional_prompt.strip():
         item_description = f"{item.color} {item.material} {item.clothing_type} ({item.other_tags}). Additional prompt: {additional_prompt}"
     else:
@@ -275,16 +282,16 @@ def generate_outfit_recommendations(item: ClothingTag, additional_prompt: str,us
         If the given item is a shoe, give recommendations for tops and bottoms. If the given item is a bottom, give recommendations for the top and shoes. \
         You may also be given additional prompts in text to constrain the style of the matched item. \
         Compile the output into a JSON which contains the description of all the items in the completed outfit. Generate 3 such outfits. "
-    
+
     response = openai_client.chat.completions.create(
         model="gpt-4o-mini",
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": item_description},
-            ],
-        tools = [create_outfit_tool],
-        tool_choice = {"type": "function", "function": {"name": "create_outfit"}})
-    
+        ],
+        tools=[create_outfit_tool],
+        tool_choice={"type": "function", "function": {"name": "create_outfit"}})
+
     parsed_response = json.loads(response.choices[0].message.tool_calls[0].function.arguments)
     top = parsed_response['top']
     bottom = parsed_response['bottom']
@@ -293,7 +300,6 @@ def generate_outfit_recommendations(item: ClothingTag, additional_prompt: str,us
     top = ClothingTag(**{**top, 'other_tags': list(top['other_tags'])})
     bottom = ClothingTag(**{**bottom, 'other_tags': list(bottom['other_tags'])})
     shoes = ClothingTag(**{**shoes, 'other_tags': list(shoes['other_tags'])})
-
 
     # recommended = {'item':item, recommended: [{'top':top, 'bottom':bottom, 'shoes':shoes}]}
     if user.recommendations == {}:
@@ -311,6 +317,7 @@ def generate_outfit_recommendations(item: ClothingTag, additional_prompt: str,us
     user.recommendations = {'item': item, 'recommended': recommended}
     return top, bottom, shoes
 
+
 def clothing_tag_to_embedding(tag: ClothingTag) -> ClothingTagEmbed:
     # TODO(maybe): Handle case where the tag is 'NIL'. Use [0,0,0....0]? Keep it as is?
     input = [tag.clothing_type, tag.color, tag.material] + tag.other_tags
@@ -325,24 +332,60 @@ def clothing_tag_to_embedding(tag: ClothingTag) -> ClothingTagEmbed:
         other_tags_embed.append(embedding_data[i].embedding)
     return ClothingTagEmbed(clothing_type_embed=clothing_type_embed, color_embed=color_embed, material_embed=material_embed, other_tags_embed=other_tags_embed)
 
-def get_n_closest(tag_embed: ClothingTagEmbed, n: int):
-    FIRST_STAGE_FILTER_RATIO = 10
+
+def get_n_closest(tag_embed: ClothingTagEmbed, n: int, category_requirement: Optional[Literal['Tops', 'Bottoms', 'Shoes', 'Dresses']] = None):
+    # If category_requirement is empty, don't use filters. Otherwise, clothing must be of the specified type.
+    # Random bucketing disabled for now.
+
+    # LIMITATIONS: other_tag matching is not by percentage of match, but by raw number of matches. This means catalogue objects with more "other_tags" will have a higher likelihood to score more.
+    # Also, after the first and second filtering stage, best match is purely by tag_match_count. (If any are equal, score from second stage is used as tie breaker)
+
+    # From n * candidate * first_stage candidates:
+    # find the n * first_stage closest matching clothing_types
+    # then find n * second_stage closest score (0.7*clothing_type + 0.3*color) (or whatever the multiplier is)
+    # then among those, find the n items with the largest number of similar tags. (See synonym_count_per_tag)
     CANDIDATE_TO_LIMIT_RATIO = 10
+    FIRST_STAGE_FILTER_RATIO = 50
+    SECOND_STAGE_FILTER_RATIO = 10
     CLOTHING_TYPE_WEIGHT = 0.7
     COLOR_WEIGHT = 0.3
 
-    bucket_count = get_catalogue_metadata().bucket_count
-    bucket_num = random.randint(1, bucket_count)
+    # How many synonyms to "exact match" for each other_tag. Eg: If it's 3, then ['simple', 'sleeveless'] might match ['simple', 'easy', 'simple design', 'sleeveless', 'no sleeves', 'short sleeves']
+    SYNONYM_COUNT_PER_TAG = 25
+
+    final_tags = []
+    for embed in tag_embed.other_tags_embed:
+        cursor = tag_embeddings.aggregate([
+            {
+                '$vectorSearch': {
+                    'index': 'embedding',
+                    'path': 'embedding',
+                    'queryVector': embed,
+                    'numCandidates': SYNONYM_COUNT_PER_TAG * CANDIDATE_TO_LIMIT_RATIO,
+                    'limit': SYNONYM_COUNT_PER_TAG,
+                }
+            },
+            {
+                '$project': {
+                    '_id': 0,
+                    'tag': 1
+                }
+            }
+        ])
+        final_tags += [item['tag'] for item in list(cursor)]
+
+    # bucket_count = get_catalogue_metadata().bucket_count
+    # bucket_num = random.randint(1, bucket_count)
 
     pipeline = [
         {
             '$vectorSearch': {
-                'index': 'vector_index',
+                'index': 'vector_search_with_category_filter',
                 'path': 'clothing_type_embed',
                 'queryVector': tag_embed.clothing_type_embed,
                 'numCandidates': n * FIRST_STAGE_FILTER_RATIO * CANDIDATE_TO_LIMIT_RATIO,
                 'limit': n * FIRST_STAGE_FILTER_RATIO,
-                'filter': {'bucket_num': bucket_num}
+                # 'filter': {'bucket_num': bucket_num}
             }
         },
         {
@@ -364,7 +407,22 @@ def get_n_closest(tag_embed: ClothingTagEmbed, n: int):
             "$sort": {"combined_score": -1}
         },
         {
-            "$limit": n
+            "$limit": n * SECOND_STAGE_FILTER_RATIO
+        },
+        {
+            '$addFields': {
+                'other_tag_match_count': {
+                    '$size': {
+                        '$setIntersection': ["$other_tags", final_tags]
+                    }
+                }
+            }
+        },
+        {
+            '$sort': {'other_tag_match_count': -1, "combined_score": -1}
+        },
+        {
+            '$limit': n
         },
         {
             '$project': {
@@ -379,23 +437,30 @@ def get_n_closest(tag_embed: ClothingTagEmbed, n: int):
                 'image_url': 1,
                 'product_url': 1,
                 'retailer': 1,
-                'gender': 1
+                'gender': 1,
+                'other_tag_match_count': 1
             }
         }
     ]
+    if category_requirement is not None:
+        pipeline[0]['$vectorSearch']['filter'] = {
+            'category': category_requirement
+        }
+
     return catalogue.aggregate(pipeline)
 
-from pydantic import BaseModel
-from typing import List
-
 # Define the StyleSuggestion and StyleAnalysisResponse models
+
+
 class StyleSuggestion(BaseModel):
     style: str
     description: str
     reasoning: str
 
+
 class StyleAnalysisResponse(BaseModel):
     top_styles: List[StyleSuggestion]
+
 
 def user_style_to_embedding(user_style: StyleAnalysisResponse) -> list[float]:
     # Combine the styles and descriptions into a single text
@@ -403,7 +468,7 @@ def user_style_to_embedding(user_style: StyleAnalysisResponse) -> list[float]:
     for style_suggestion in user_style.top_styles:
         style_texts.append(f"{style_suggestion.style}: {style_suggestion.description}")
     combined_style_text = " ".join(style_texts)
-    
+
     # Get the embedding
     embedding_response = openai_client.embeddings.create(
         input=combined_style_text, model="text-embedding-3-large"
@@ -411,9 +476,10 @@ def user_style_to_embedding(user_style: StyleAnalysisResponse) -> list[float]:
     embedding = embedding_response.data[0].embedding
     return embedding
 
+
 def get_wardrobe_recommendation(tag: WardrobeTag, profile: dict, additional_prompt: str = "") -> list[ClothingTag]:
-    #added user persona 23/02
-    
+    # added user persona 23/02
+
     tag_dict = tag.model_dump()
     if additional_prompt != "":
         tag_dict["additional_prompt"] = additional_prompt
@@ -426,8 +492,8 @@ def get_wardrobe_recommendation(tag: WardrobeTag, profile: dict, additional_prom
                 "role": "system",
                 "content": [
                     {
-                    "type": "text",
-                    "text": f"""You are a personal stylist, your task is to generate a complete outfit based off a starting item. You will be given a starting item as JSON input containing: name (description of item), category (top, bottom, shoes, layer) and tags (style tags).\n\nA complete outfit:\n- Either (dress + shoes) \n- Or (one top + one bottom + shoes)\n- Optionally include one layering piece (e.g., jacket) if it matches the style and context.\n\nCreating an outfit:\n1.) analyse the style of the given item and additional context to select an outfit style. \n2.) based off the category of the item and the definition of an outfit, identify the other categories required to complete an outfit. You can only have 1 item from each category. There should be a maximum 3 unique categories in the output.\n3.)recommend clothing items in these categories that match the overall outfit style. Output the different items of the outfit in JSON with the tags: clothing_type (descriptor of the item) , color, material, and other_tags (category, comma separated styles, ocassion, fit, color, material)\n\nCarefully consider the style of the input, the users preferences defined below and the additional context (if any) when choosing the overall style of the outfit. Take inspiration from user preferences but include some variation. Ensure only one item per category in the outfit. Do not include the starting item or the same category in the output. Ensure a complete outfit can be created with the recommended items.\n\n
+                        "type": "text",
+                        "text": f"""You are a personal stylist, your task is to generate a complete outfit based off a starting item. You will be given a starting item as JSON input containing: name (description of item), category (top, bottom, shoes, layer) and tags (style tags).\n\nA complete outfit:\n- Either (dress + shoes) \n- Or (one top + one bottom + shoes)\n- Optionally include one layering piece (e.g., jacket) if it matches the style and context.\n\nCreating an outfit:\n1.) analyse the style of the given item and additional context to select an outfit style. \n2.) based off the category of the item and the definition of an outfit, identify the other categories required to complete an outfit. You can only have 1 item from each category. There should be a maximum 3 unique categories in the output.\n3.)recommend clothing items in these categories that match the overall outfit style. Output the different items of the outfit in JSON with the tags: clothing_type (descriptor of the item) , color, material, and other_tags (category, comma separated styles, ocassion, fit, color, material)\n\nCarefully consider the style of the input, the users preferences defined below and the additional context (if any) when choosing the overall style of the outfit. Take inspiration from user preferences but include some variation. Ensure only one item per category in the outfit. Do not include the starting item or the same category in the output. Ensure a complete outfit can be created with the recommended items.\n\n
                     User Persona: {profile['age']}-year-old {profile['gender']} in {profile['location']}, {profile['skin_tone']} skin, {profile['style']} style.
                     Likes: {profile['clothing_likes']}.
                     Likes: {profile['clothing_likes']}.
@@ -520,6 +586,7 @@ def get_wardrobe_recommendation(tag: WardrobeTag, profile: dict, additional_prom
 
     return clothing_tags
 
+
 def get_n_closest_with_filter(tag_embed: ClothingTagEmbed, category: str, n: int):
     """
     Returns the n closest items in the specified category using vector search.
@@ -593,91 +660,91 @@ def get_n_closest_with_filter(tag_embed: ClothingTagEmbed, category: str, n: int
 
 
 def get_user_feedback_recommendation(starting_item: WardrobeTag, disliked_item: WardrobeTag, dislike_reason: str, profile: dict):
-    #generates a new recommendation given a disliked previous one. Should be called when user dislikes a recommended item from the wardrobe page.
-    #TODO need to figure out how to pass the outfit style of the starting item
-    #TODO include additional prompts in the recommendation
-    
+    # generates a new recommendation given a disliked previous one. Should be called when user dislikes a recommended item from the wardrobe page.
+    # TODO need to figure out how to pass the outfit style of the starting item
+    # TODO include additional prompts in the recommendation
+
     outfit_style = starting_item.tags[:3]
-    #[styles, ocassion, fit, color, material] --> hardcoded order in generate_wardrobe_tags, we only use the first 3 to determine the outfit style
+    # [styles, ocassion, fit, color, material] --> hardcoded order in generate_wardrobe_tags, we only use the first 3 to determine the outfit style
 
     response = openai_client.chat.completions.create(
-    model="gpt-4o-mini",
-    messages=[
-        {
-        "role": "system",
-        "content": [
+        model="gpt-4o-mini",
+        messages=[
             {
-            "text": f"You are a fashion stylist recommending clothes to a user. The user wants to generate an alternative for a single item from an outfit because of some dislike reason. You will be given the disliked item as a JSON with the following tags: \"name\" (description of the item), \"category\" (top, bottom, shoes), \"tags\" (style descriptors). You will also be given style descriptors of the outfit.\n\n1.) Store the category of the disliked. You should only recommend an item from the same category.\n2.) Use the style descriptors of the outfit to gauge the style of the item you will be generating.\n3.) The dislike reason will be given as one of the tags of the item, change that when generating the new outfit. Only the dislike reason should be drastically changed, try to keep other factors the same. You should act as a sales rep suggesting an alternative, not a completely new item.\n\nOutput the new recommendation in JSON with the tags: clothing_type (descriptor of the item) , color, material, and other_tags (category, comma separated styles, ocassion, fit, color, material)\n\nUser Persona: {profile['age']}-year-old {profile['gender']} in {profile['location']}, with {profile['style']} style. Likes: {profile['clothing_likes']}. Dislikes: {profile['clothing_dislikes']}.",
-            "type": "text"
+                "role": "system",
+                "content": [
+                    {
+                        "text": f"You are a fashion stylist recommending clothes to a user. The user wants to generate an alternative for a single item from an outfit because of some dislike reason. You will be given the disliked item as a JSON with the following tags: \"name\" (description of the item), \"category\" (top, bottom, shoes), \"tags\" (style descriptors). You will also be given style descriptors of the outfit.\n\n1.) Store the category of the disliked. You should only recommend an item from the same category.\n2.) Use the style descriptors of the outfit to gauge the style of the item you will be generating.\n3.) The dislike reason will be given as one of the tags of the item, change that when generating the new outfit. Only the dislike reason should be drastically changed, try to keep other factors the same. You should act as a sales rep suggesting an alternative, not a completely new item.\n\nOutput the new recommendation in JSON with the tags: clothing_type (descriptor of the item) , color, material, and other_tags (category, comma separated styles, ocassion, fit, color, material)\n\nUser Persona: {profile['age']}-year-old {profile['gender']} in {profile['location']}, with {profile['style']} style. Likes: {profile['clothing_likes']}. Dislikes: {profile['clothing_dislikes']}.",
+                        "type": "text"
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"disliked_item ({disliked_item})\n\noutfit_style ({outfit_style})\n\ndislike_reason({dislike_reason})"
+                    }
+                ]
             }
-        ]
+        ],
+        response_format={
+            "type": "json_object"
         },
-        {
-        "role": "user",
-        "content": [
+        tools=[
             {
-            "type": "text",
-            "text": f"disliked_item ({disliked_item})\n\noutfit_style ({outfit_style})\n\ndislike_reason({dislike_reason})"
-            }
-        ]
-        }
-    ],
-    response_format={
-        "type": "json_object"
-    },
-    tools=[
-        {
-        "type": "function",
-        "function": {
-            "name": "feedback_single_item",
-            "strict": True,
-            "parameters": {
-            "type": "object",
-            "required": [
-                "clothing_type",
-                "color",
-                "material",
-                "other_tags"
-            ],
-            "properties": {
-                "color": {
-                "type": "string",
-                "description": "color of clothing item"
-                },
-                "material": {
-                "type": "string",
-                "description": "Material of the clothing item (e.g., cotton, wool, polyester)"
-                },
-                "other_tags": {
-                "type": "array",
-                "items": {
-                    "type": "string",
-                    "description": "A style tag (e.g., casual, formal, vintage)"
-                },
-                "description": "Any other tags that describe the item's style"
-                },
-                "clothing_type": {
-                "type": "string",
-                "description": "Type of clothing item (e.g., shirt, pants, dress)"
+                "type": "function",
+                "function": {
+                    "name": "feedback_single_item",
+                    "strict": True,
+                    "parameters": {
+                        "type": "object",
+                        "required": [
+                            "clothing_type",
+                            "color",
+                            "material",
+                            "other_tags"
+                        ],
+                        "properties": {
+                            "color": {
+                                "type": "string",
+                                "description": "color of clothing item"
+                            },
+                            "material": {
+                                "type": "string",
+                                "description": "Material of the clothing item (e.g., cotton, wool, polyester)"
+                            },
+                            "other_tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "description": "A style tag (e.g., casual, formal, vintage)"
+                                },
+                                "description": "Any other tags that describe the item's style"
+                            },
+                            "clothing_type": {
+                                "type": "string",
+                                "description": "Type of clothing item (e.g., shirt, pants, dress)"
+                            }
+                        },
+                        "additionalProperties": False
+                    },
+                    "description": "Describes a clothing item with its features."
                 }
-            },
-            "additionalProperties": False
-            },
-            "description": "Describes a clothing item with its features."
-        }
-        }
-    ],
-    tool_choice={
-        "type": "function",
-        "function": {
-        "name": "feedback_single_item"
-        }
-    },
-    temperature=1,
-    max_completion_tokens=2048,
-    top_p=1,
-    frequency_penalty=0,
-    presence_penalty=0
+            }
+        ],
+        tool_choice={
+            "type": "function",
+            "function": {
+                "name": "feedback_single_item"
+            }
+        },
+        temperature=1,
+        max_completion_tokens=2048,
+        top_p=1,
+        frequency_penalty=0,
+        presence_penalty=0
     )
 
     output = response.choices[0].message.tool_calls[0].function.arguments

--- a/services/openai.py
+++ b/services/openai.py
@@ -345,8 +345,8 @@ def get_n_closest(tag_embed: ClothingTagEmbed, n: int, category_requirement: Opt
     # then find n * second_stage closest score (0.7*clothing_type + 0.3*color) (or whatever the multiplier is)
     # then among those, find the n items with the largest number of similar tags. (See synonym_count_per_tag)
     CANDIDATE_TO_LIMIT_RATIO = 10
-    FIRST_STAGE_FILTER_RATIO = 50
-    SECOND_STAGE_FILTER_RATIO = 10
+    FIRST_STAGE_FILTER_RATIO = 100
+    SECOND_STAGE_FILTER_RATIO = 20
     CLOTHING_TYPE_WEIGHT = 0.7
     COLOR_WEIGHT = 0.3
 
@@ -588,6 +588,7 @@ def get_wardrobe_recommendation(tag: WardrobeTag, profile: dict, additional_prom
 
 
 def get_n_closest_with_filter(tag_embed: ClothingTagEmbed, category: str, n: int):
+    print("############ IMPORTANT #########\n\n\n'get_n_closest_with_filter' is deprecated. Use get_n_closest instead, it has an optional argument.")
     """
     Returns the n closest items in the specified category using vector search.
     """


### PR DESCRIPTION
**Basis of how it works:**

Given other_tags, we try to find synonyms using the 'tag_embeddings' page Jordan created. Eg: ['simple', 'sleeveless'] might gets expanded to ['simple', 'easy', 'simple design', 'sleeveless', 'no sleeves', 'short sleeves']. Currently, the multiplier fetches 25 synonym for each other_tag.

Then we do a matching pipeline. Where n is the number of best matches we want to get in the end:
Get top 100\*n closest matches of clothing_type
Get top 20\*n closest matches of 0.7\*clothing_type + 0.3\*color (combined_score)
Finally, get top n matches based on the number of tags. If there are equal number of tags between two items, tiebreaker is by the highest combined_score.

**`get_n_closest` now also supports an optional argument category_requirement. `get_n_closest_with_filter` will be deprecated.**

Random bucketing disabled for now.

**LIMITATIONS**: other_tag matching is not by percentage of match, but by raw number of matches. This means catalogue objects with more "other_tags" will have a higher likelihood to score more.
Also, after the first and second filtering stage, best match is purely by tag_match_count.